### PR TITLE
IPI and GI deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-
-jdk:
-  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,3 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
-  - openjdk6

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-[![Build Status](https://travis-ci.org/PRIDE-Utilities/protein-details-fetcher.svg?branch=master)](https://travis-ci.org/PRIDE-Utilities/protein-details-fetcher)

--- a/pom.xml
+++ b/pom.xml
@@ -9,77 +9,18 @@
 
     <name>protein-details-fetcher</name>
 
-    <developers>
-        <developer>
-            <id>jgriss</id>
-            <name>Johannes Griss</name>
-            <email>jgriss@ebi.ac.uk</email>
-            <organization>European Bioinformatics Institute</organization>
-            <organizationUrl>http://ebi.ac.uk/pride</organizationUrl>
-        </developer>
-        <developer>
-            <id>ypriverol</id>
-            <name>Yasset Perez-Riverol</name>
-            <email>yperez@ebi.ac.uk</email>
-            <organization>European Bioinformatics Institute</organization>
-            <organizationUrl>http://ebi.ac.uk/pride</organizationUrl>
-        </developer>
-    </developers>
-    <organization>
-        <name>European Bioinformatics Institute</name>
-        <url>http://www.ebi.ac.uk</url>
-    </organization>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <remoteTagging>true</remoteTagging>
-                    <goals>deploy</goals>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <parent>
+        <groupId>uk.ac.ebi.pride.architectural</groupId>
+        <artifactId>pride-core</artifactId>
+        <version>1.0.1</version>
+    </parent>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -94,12 +35,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>0.9.24</version>
+            <version>1.0.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>0.9.24</version>
+            <version>1.0.7</version>
         </dependency>
         <dependency>
             <groupId>jdom</groupId>
@@ -112,37 +53,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>nexus-ebi-release-repo</id>
-            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
-        </repository>
-        <repository>
-            <id>nexus-ebi-snapshot-repo</id>
-            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-snapshots/</url>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <!-- EBI repo -->
-        <repository>
-            <id>pst-release</id>
-            <name>EBI Nexus Repository</name>
-            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <snapshotRepository>
-            <uniqueVersion>false</uniqueVersion>
-            <id>pst-snapshots</id>
-            <name>EBI Nexus Snapshots Repository</name>
-            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <scm>
-        <connection>scm:git:github.com/PRIDE-Utilities/protein-details-fetcher.git</connection>
-        <developerConnection>scm:git:git@github.com:PRIDE-Utilities/protein-details-fetcher.git</developerConnection>
-        <url>https://github.com/PRIDE-Utilities/protein-details-fetcher.git</url>
+        <connection>scm:git:https://github.com/PRIDE-Utilities/protein-details-fetcher.git</connection>
+        <developerConnection>scm:git:https://github.comPRIDE-Utilities/protein-details-fetcher.git</developerConnection>
+        <url>https://github.com/PRIDE-Utilities/protein-details-fetcher</url>
         <tag>HEAD</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
         <version>1.0.1</version>
     </parent>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -49,9 +53,6 @@
         </dependency>
     </dependencies>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 
     <scm>
         <connection>scm:git:https://github.com/PRIDE-Utilities/protein-details-fetcher.git</connection>

--- a/src/main/java/uk/ac/ebi/pride/tools/protein_details_fetcher/ProteinDetailFetcher.java
+++ b/src/main/java/uk/ac/ebi/pride/tools/protein_details_fetcher/ProteinDetailFetcher.java
@@ -3,16 +3,13 @@ package uk.ac.ebi.pride.tools.protein_details_fetcher;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.input.SAXBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,849 +20,484 @@ import uk.ac.ebi.pride.tools.protein_details_fetcher.util.ProteinAccessionPatter
 
 public class ProteinDetailFetcher {
 
-    private static final Logger logger = LoggerFactory.getLogger(ProteinDetailFetcher.class);
-	
-	private static final String TAB = "\t";
-	private static final String EOL = "\n";
+  private static final Logger logger = LoggerFactory.getLogger(ProteinDetailFetcher.class);
 
-    private static final String UNIPROT_PROTEIN = "P31946L";
+  private static final String TAB = "\t";
+  private static final String EOL = "\n";
+  private static final String UNIPROT_PROTEIN = "P31946L";
 
 
-	/**
-	 * Queries used to fetch the actual protein
-	 * details.
-	 * @author jg
-	 *
-	 */
-	public enum DETAILS_QUERY{
-		NCBI_FASTA("http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=protein&id=%s&rettype=fasta&tool=protein_details_fetcher"),
-		UNIPROT("http://www.uniprot.org/uniprot/?query=%s&format=tab&columns=id,protein%%20names,sequence,reviewed,entry%%20name,organism-id"),
-        UNIPROT_FASTA("http://www.uniprot.org/uniprot/%s");
-		
-		private String queryString;
-		
-		private DETAILS_QUERY(String formatString) {
-			this.queryString = formatString;
-		}
-		
-		public String getQueryString() {
-			return queryString;
-		}
-	}
-	
-	/**
-	 * Queries used to map accession systems.
-	 * @author jg
-	 *
-	 */
-	public enum MAPPING_QUERY {
-		ENSEMBL_TO_UNIPROT("http://www.uniprot.org/mapping/?from=ENSEMBL_PRO_ID&to=ACC&query=%s&format=tab"),
-		IPI_TO_UNIPROT("http://www.uniprot.org/mapping/?from=P_IPI&to=&query=%s&format=tab");
-		
-		private String queryString;
-		
-		private MAPPING_QUERY(String queryString) {
-			this.queryString = queryString;
-		}
-		
-		public String getQueryString() {
-			return queryString;
-		}
-	}
-	
-	/**
-	 * Supported types of protein accessions.
-	 * @author jg
-	 *
-	 */
-	private enum AccessionType{UNIPROT_ACC, UNIPROT_ID, UNIPARC, IPI, REFSEQ, ENSEMBL, GI, UNKNOWN}
-	
-    // query string for the NCBI esummary tool
-    private final String ESUMMARY_QUERY_STRING = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=protein&id=%s";
-    // query string for the NCBI esearch tool
-    private final String ESEARCH_QUERY_STRING = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=protein&term=%s";
-    // query string to fetch the protein sequence from NCBI
-    private final String EFETCH_FORMAT_STRING = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=protein&id=%s&rettype=fasta&tool=pride_inspector";
+  /**
+   * Queries used to fetch the actual protein
+   * details.
+   * @author jg
+   *
+   */
+  public enum DETAILS_QUERY{
+    NCBI_FASTA("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=protein&id=%s&rettype=fasta&tool=protein_details_fetcher"),
+    UNIPROT("http://www.uniprot.org/uniprot/?query=%s&format=tab&columns=id,protein%%20names,sequence,reviewed,entry%%20name,organism-id"),
+    UNIPROT_FASTA("http://www.uniprot.org/uniprot/%s");
 
-    private HashMap<String, String> pageBuffer = new HashMap<String, String>();
-    // TODO: in case this class should be used in a multi-thread environment, this member variable should be changed to static + concurrentHashMap
+    private String queryString;
 
-    /**
-     * Returns the (guessed) accession type for the passed
-     * accession. In case the accession is not recognized
-     * UNKNOWN is returned.
-     * @param accession The accession to guess the type for.
-     * @return The accession's type.
-     */
-    private AccessionType getAccessionType(String accession) {
-    	// swissprot accession
-    	if (ProteinAccessionPattern.isSwissprotAccession(accession))
-            return AccessionType.UNIPROT_ACC;
-    	
-    	if (ProteinAccessionPattern.isSwissprotEntryName(accession))
-    		return AccessionType.UNIPROT_ID;
-
-        // uniparc
-        if (ProteinAccessionPattern.isUniparcAccession(accession))
-            return AccessionType.UNIPARC;
-
-        // IPI
-        if (ProteinAccessionPattern.isIPIAccession(accession))
-        	return AccessionType.IPI;
-
-        // ENSEMBL
-        if (ProteinAccessionPattern.isEnsemblAccession(accession))
-        	return AccessionType.ENSEMBL;
-
-        // NCBI
-        if (ProteinAccessionPattern.isRefseqAccession(accession))
-        	return AccessionType.REFSEQ;
-
-        // GI
-        if (ProteinAccessionPattern.isGIAccession(accession))
-        	return AccessionType.GI;
-        
-        return AccessionType.UNKNOWN;
+    DETAILS_QUERY(String formatString) {
+      this.queryString = formatString;
     }
-    
-    /**
-     * Returns various details for the given protein (f.e. name,
-     * sequence).
-     * @param accessions The protein's accession.
-     * @return A Protein object containing the additional information.
-     * @throws Exception error when retrieving protein accession
-     */
-    public HashMap<String, Protein> getProteinDetails(Collection<String> accessions) throws Exception {
-    	// sort the passed accessions into Lists based on the (guessed) identifier system
-    	HashMap<AccessionType, ArrayList<String>> sortedAccessions = new HashMap<AccessionType, ArrayList<String>>();
-    	
-    	for (String accession : accessions) {
-    		// get the accessions type
-    		AccessionType accType = getAccessionType(accession);
-    		
-    		// put the accession in the respective ArrayList
-    		if (!sortedAccessions.containsKey(accType))
-    			sortedAccessions.put(accType, new ArrayList<String>());
-    		
-    		// remove any version information from the accession
-    		accession = accession.replaceAll("\\.\\d+$", "");
-    		sortedAccessions.get(accType).add(accession);
-    	}
-    	
-    	// map the accessions
-    	HashMap<String, Protein> proteins = new HashMap<String, Protein>();
-    	for (AccessionType accType : sortedAccessions.keySet()) {
-    		switch(accType) {
-    			case UNIPROT_ACC:
-    				proteins.putAll(getUniProtDetails(sortedAccessions.get(accType)));
-    				break;
-    			case UNIPROT_ID:
-    				proteins.putAll(getUniProtDetails(sortedAccessions.get(accType)));
-    				break;
-    			case IPI:
-    				proteins.putAll(getIpiDetails(sortedAccessions.get(accType)));
-    				break;
-    			case ENSEMBL:
-    				proteins.putAll(getEnsemblDetails(sortedAccessions.get(accType)));
-    				break;
-    			case GI:
-    				proteins.putAll(getNcbiDetails(sortedAccessions.get(accType), true));
-    				break;
-    			case REFSEQ:
-    				proteins.putAll(getNcbiDetails(sortedAccessions.get(accType), false));
-    				break;
-    		}
-    	}
-    	
-    	// add empty protein objects for all proteins that could not be retrieved
-    	// and set the status to DELETED
-    	for (String accession : accessions) {
-    		// remove any version information from the accession
-    		accession = accession.replaceAll("\\.\\d+$", "");
-    		
-    		if (!proteins.containsKey(accession)) {
-    			Protein p = new Protein(accession);
-    			p.setStatus(STATUS.UNKNOWN);
-    			proteins.put(accession, p);
-    		}
-    	}
-    	
-        return proteins;
+
+    public String getQueryString() {
+      return queryString;
     }
-    
-    /**
-     * Returns the details for the given identifiers in
-     * a HashMap with the identifier's key or GI number as key and a Protein
-     * object holding the details as value.
-     *
-     * @param accessions The accession to get the details for.
-     * @return A Protein object containing the protein's details.
-     * @throws Exception
-     */
-    private HashMap<String, Protein> getNcbiDetails(Collection<String> accessions, boolean useGiNumber) throws Exception {
-    	// create the query string
-    	String query = "";
-    	
-    	for (String accession : accessions)
-    		query += ((query.length() > 0) ? "," : "") + accession;
-    	
-    	// get the IPI fasta entry
-        String fastas = getPage(String.format(DETAILS_QUERY.NCBI_FASTA.getQueryString(), query));
-        String[] lines = fastas.split(EOL);
-        
-        // parse the fasta entries
-        String fasta = "";
-        
-        HashMap<String, Protein> proteins = new HashMap<String, Protein>();
-        
-        for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-        	String line = lines[lineIndex];
-        	
-        	// process the current fasta
-        	if (fasta.length() > 0 && line.startsWith(">")) {
-        		Protein protein = convertNcbiFastaToProtein(fasta, useGiNumber);
-        		if (protein != null) {
-        			String accessionNoVersion = protein.getAccession().replaceAll("\\.\\d+$", "");
-        			proteins.put(accessionNoVersion, protein);
-        		}
-                
-                fasta = "";
-        	}
-        	
-        	fasta += line + EOL;
+  }
+
+  /**
+   * Queries used to map accession systems.
+   * @author jg
+   *
+   */
+  public enum MAPPING_QUERY {
+    ENSEMBL_TO_UNIPROT("http://www.uniprot.org/mapping/?from=ENSEMBL_PRO_ID&to=ACC&query=%s&format=tab");
+
+    private String queryString;
+
+    MAPPING_QUERY(String queryString) {
+      this.queryString = queryString;
+    }
+
+    public String getQueryString() {
+      return queryString;
+    }
+  }
+
+  /**
+   * Supported types of protein accessions.
+   * @author jg
+   *
+   */
+  private enum AccessionType{UNIPROT_ACC, UNIPROT_ID, UNIPARC, REFSEQ, ENSEMBL, UNKNOWN}
+
+  /**
+   * Returns the (guessed) accession type for the passed
+   * accession. In case the accession is not recognized
+   * UNKNOWN is returned.
+   * @param accession The accession to guess the type for.
+   * @return The accession's type.
+   */
+  private AccessionType getAccessionType(String accession) {
+    AccessionType result = AccessionType.UNKNOWN;
+    if (ProteinAccessionPattern.isSwissprotAccession(accession)) {
+      result =  AccessionType.UNIPROT_ACC; // swissprot accession
+    } else if (ProteinAccessionPattern.isSwissprotEntryName(accession)) {
+      result = AccessionType.UNIPROT_ID; // swissprot entry
+    } else if (ProteinAccessionPattern.isUniparcAccession(accession)) {
+      result = AccessionType.UNIPARC; // uniparc
+    } else if (ProteinAccessionPattern.isEnsemblAccession(accession)) {
+      result = AccessionType.ENSEMBL; // ENSEMBL
+    } else  if (ProteinAccessionPattern.isRefseqAccession(accession)) {
+      result = AccessionType.REFSEQ; // NCBI
+    }
+    return result;
+  }
+
+  /**
+   * Returns various details for the given protein (f.e. name,
+   * sequence).
+   * @param accessions The protein's accession.
+   * @return A Protein object containing the additional information.
+   * @throws Exception error when retrieving protein accession
+   */
+  public HashMap<String, Protein> getProteinDetails(Collection<String> accessions) throws Exception {
+    HashMap<AccessionType, ArrayList<String>> sortedAccessions = new HashMap<>();
+    for (String accession : accessions) {
+      AccessionType accType = getAccessionType(accession);
+      if (!sortedAccessions.containsKey(accType)) {
+        sortedAccessions.put(accType, new ArrayList<>());
+      }
+      accession = accession.replaceAll("\\.\\d+$", "");
+      sortedAccessions.get(accType).add(accession);
+    }
+    HashMap<String, Protein> proteins = new HashMap<>();
+    for (AccessionType accType : sortedAccessions.keySet()) {
+      switch(accType) {
+        case UNIPROT_ACC:
+          proteins.putAll(getUniProtDetails(sortedAccessions.get(accType)));
+          break;
+        case UNIPROT_ID:
+          proteins.putAll(getUniProtDetails(sortedAccessions.get(accType)));
+          break;
+        case ENSEMBL:
+          proteins.putAll(getEnsemblDetails(sortedAccessions.get(accType)));
+          break;
+        case REFSEQ:
+          proteins.putAll(getNcbiDetails(sortedAccessions.get(accType)));
+          break;
+      }
+    }
+    for (String accession : accessions) {
+      accession = accession.replaceAll("\\.\\d+$", ""); // remove any version information from the accession
+      if (!proteins.containsKey(accession)) {
+        Protein p = new Protein(accession); // add empty protein objects for all proteins that could not be retrieved
+        p.setStatus(STATUS.UNKNOWN);
+        proteins.put(accession, p);
+      }
+    }
+    return proteins;
+  }
+
+  /**
+   * Returns the details for the given identifiers in
+   * a HashMap with the identifier's key or GI number as key and a Protein
+   * object holding the details as value.
+   *
+   * @param accessions The accession to get the details for.
+   * @return A Protein object containing the protein's details.
+   * @throws Exception any problems getting NCBI details
+   */
+  private HashMap<String, Protein> getNcbiDetails(Collection<String> accessions) throws Exception {
+    StringBuilder query = new StringBuilder();
+    for (String accession : accessions) {
+      query.append((query.length() > 0) ? "," : "").append(accession);
+    }
+    String fastas = getPage(String.format(DETAILS_QUERY.NCBI_FASTA.getQueryString(), query.toString()));
+    String[] lines = fastas.split(EOL);
+    StringBuilder fasta = new StringBuilder(); // parse the fasta entries
+    HashMap<String, Protein> proteins = new HashMap<>();
+    for (String line : lines) {
+      if (fasta.length() > 0 && line.startsWith(">")) {
+        Protein protein = convertNcbiFastaToProtein(fasta.toString());
+        if (protein != null) {
+          String accessionNoVersion = protein.getAccession().replaceAll("`.\\d+$", "");
+          proteins.put(accessionNoVersion, protein);
         }
-        
-        if (!"".equals(fasta)) {
-        	Protein protein = convertNcbiFastaToProtein(fasta, useGiNumber);
-        	
-        	if (protein != null)
-        		proteins.put(protein.getAccession(), protein);
-        }
-        
-       proteins = enrichNCBIProteins(proteins);
-        
-       return proteins;
+        fasta = new StringBuilder();
+      }
+      fasta.append(line).append(EOL);
     }
-    
-        private HashMap<String, Protein> enrichNCBIProteins(HashMap<String, Protein> proteins) throws Exception {
-		// build the query
-    	String query = "";
-    	
-    	for (String accession : proteins.keySet()) {
-    		Protein p = proteins.get(accession);    		
-    		query += (query.length() > 0 ? "," : "") + p.getProperty(PROPERTY.GI_NUMBER);
-    	}
-    	
-    	// get the result
-    	String page = getPage(String.format(ESUMMARY_QUERY_STRING, query));
-    	
-    	// get the properties
-    	HashMap<Integer, HashMap<String, String>> proteinProperties = getNcbiProperties(page);
-    	
-    	// enrich the existing proteins
-    	for (Protein p : proteins.values()) {
-    		// get the properties
-    		HashMap<String, String> properties = proteinProperties.get(Integer.parseInt(p.getProperty(PROPERTY.GI_NUMBER)));
-    		
-    		if (properties != null && !properties.isEmpty() && properties.containsKey("Status")) {
-    			// check the status
-    			String status = properties.get("Status");
-    			
-    			if ("live".equals(status))
-    				p.setStatus(STATUS.ACTIVE);
-    			else if (!"live".equals(status) && (properties.get("ReplacedBy") == null || "".equals(properties.get("ReplacedBy"))))
-    				p.setStatus(STATUS.DELETED);
-    			else {
-    				p.setStatus(STATUS.CHANGED); 
-    				
-    				String replacedBy = properties.get("ReplacedBy");
-    				p.getReplacingProteins().add(new Protein(replacedBy));
-    			}
-    		}
-    	}
-    	
-    	return proteins;
-	}
-    
-
-
-    /**
-     * Returns the properties of the given identifier fetched
-     * using the NCBI esummary tool and returns them as a HashMap.
-     *
-     * @param xml The accession to retrieve the properties for.
-     * @return A HashMap with the property's name as key and its value as value.
-     * @throws Exception Thrown in case something went wrong.
-     */
-    private HashMap<Integer, HashMap<String, String>> getNcbiProperties(String xml) throws Exception {
-        // create the xml object
-        SAXBuilder builder = new SAXBuilder();
-        Document doc = builder.build(new StringReader(xml));
-
-        // get the document summary element
-        Element root = doc.getRootElement();
-
-        if (root == null)
-            throw new Exception("Failed to parse NCBI XML snipplet");
-
-        @SuppressWarnings("unchecked")
-		List<Element> docSums = root.getChildren("DocSum");
-        HashMap<Integer, HashMap<String, String>> elementProperties = new HashMap<Integer, HashMap<String,String>>();
-        
-        for (Element docSum : docSums) {
-	        if (docSum == null)
-	            throw new Exception("Failed to parse NCBI XML snipplet");
-	
-	        // get all the items
-	        @SuppressWarnings("unchecked")
-			List<Element> items = docSum.getChildren("Item");
-	
-	        // initialize the return variable
-	        HashMap<String, String> properties = new HashMap<String, String>();
-	
-	        // parse the items
-	        for (Element item : items) {
-				if(item.getAttributes().contains("Name")) {
-					properties.put(item.getAttributeValue("Name"), item.getValue());
-				}
-	        }
-	        
-	        // get the id
-	        String gi = docSum.getChildText("Id");
-	        
-	        elementProperties.put(Integer.parseInt(gi), properties);
-        }
-
-        return elementProperties;
+    if (!StringUtils.isEmpty(fasta.toString())) {
+      Protein protein = convertNcbiFastaToProtein(fasta.toString());
+      if (protein != null)
+        proteins.put(protein.getAccession(), protein);
     }
+    return proteins;
+  }
 
-	/**
-     * Converts an NCBI gi fasta entry to a Protein object.
-     * @param fasta The fasta to convert.
-     * @param useGi Indicates whether the GI number or the source accession should be set as the Protein's accession.
-     * @return Protein Returns the converter Protein object or null in case nothing was found.
-     * @throws Exception
-     */
-    private Protein convertNcbiFastaToProtein(String fasta, boolean useGi) throws Exception {
-    	// make sure something was found
-    	if (fasta.trim().length()==0 || (!fasta.startsWith(">") && fasta.contains("Nothing has been found"))) {
-    		return null;
-    	}    		
-    	
-    	// only use the first line
-        String header = fasta.substring(0, fasta.indexOf(EOL));
-        
-        // get the sequence
-        String sequence = fasta.substring(fasta.indexOf(EOL) + 1);
-        // remove all whitespaces
+  /**
+   * Converts an NCBI gi fasta entry to a Protein object.
+   * @param fasta The fasta to convert.
+   * @return Protein Returns the converter Protein object or null in case nothing was found.
+   * @throws Exception any problems mapping to a protein
+   */
+  private Protein convertNcbiFastaToProtein(String fasta) throws Exception {
+    if (fasta.trim().length()==0 || (!fasta.startsWith(">") && fasta.contains("Nothing has been found"))) {
+      return null;
+    }
+    String header = fasta.substring(0, fasta.indexOf(EOL)); // only use the first line
+    String sequence = fasta.substring(fasta.indexOf(EOL) + 1);
+    Pattern pat = Pattern.compile(">(\\S+)\\s([^\\n]+)"); // extract the protein name
+    Matcher matcher = pat.matcher(header);
+    if (!matcher.find()) {
+      throw new Exception("Unexpected fasta format encountered:\n" + fasta);
+    }
+    String accession = matcher.group(1);
+    String name = matcher.group(2).trim();
+    String accessionVersion = null;
+    if (accession != null) {
+      int index = accession.lastIndexOf('.');
+      if (index != -1) {
+        accessionVersion = accession.substring(index + 1);
+      }
+      accession = accession.replaceAll("\\.\\d+", ""); // remove the version info from the accession
+    }
+    Protein protein = new Protein(accession);
+    protein.setName(name);
+    protein.setSequenceString(sequence);
+    protein.setProperty(PROPERTY.SOURCE, "NCBI accession");
+    if (accessionVersion != null) {
+      protein.setProperty(PROPERTY.ACCESSION_VERSION, accessionVersion);
+    }
+    logger.info("Protein: " + protein.getName() + " " + protein.getAccession() + " " + protein.getSequenceString());
+    return protein;
+  }
+
+  /**
+   * Retrieves the protein details from UniProt from the
+   * given UniProt accessions. Returns null in case nothing
+   * was retrieved. <br />
+   * <b>Warning:</b> The function first tries to retrieve the protein details
+   * expecting them to be accessions. Only if no results are retrieved that way
+   * a second request is send interpreting the passed strings as ids. In case
+   * accessions and ids are mixed, only the proteins identified through accessions
+   * will be returned.
+   * @param accessions The UniProt accessions of the proteins.
+   * @return A Collection of Protein objects containing the proteins' details or null if the accession doesn't exist
+   * @throws Exception In case something went wrong
+   */
+  private Map<String, Protein> getUniProtDetails(Collection<String> accessions) throws Exception {
+    StringBuilder query = new StringBuilder();
+    Boolean usingAccession = true;
+    List<String> isoforms = new ArrayList<>();
+    for (String accession : accessions) {
+      if(accession.contains("-") || accession.contains("-")){
+        query.append((query.length() > 1) ? "%20or%20" : "").append("sequence:").append(accession);
+        isoforms.add(accession);
+      }else{
+        query.append((query.length() > 1) ? "%20or%20" : "").append("accession:").append(accession);
+      }
+    }
+    String url = String.format(DETAILS_QUERY.UNIPROT.getQueryString(), query.toString());
+    String page = getPage(url);
+    if ("".equals(page.trim())) {
+      usingAccession = false;
+      page = getPage(String.format(DETAILS_QUERY.UNIPROT.getQueryString(), query.toString().replace("accession:", "mnemonic:")));
+    }
+    if(page.equals("")){
+      return Collections.emptyMap();
+    }
+    String[] lines = page.split(EOL);
+    if (lines.length < 2) {
+      return Collections.emptyMap();
+    }
+    Map<String,String> isoformMapSequence = new HashMap<>();
+    if(isoforms.size() > 0)
+      isoformMapSequence = getFastaSequencePage(isoforms);
+    HashMap<String, Integer> fieldIndex = new HashMap<>();
+    HashMap<String, Protein> proteins = new HashMap<>();
+    for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      String[] fields = lines[lineIndex].split(TAB);
+      if (lineIndex == 0) {  // if it's the first line build the field index
+        fieldIndex.put("Entry", 0); //hard coding due to Uniprot header bug [help #132525]
+        fieldIndex.put("Protein names", 1);
+        fieldIndex.put("Sequence", 2);
+        fieldIndex.put("Status", 3);
+        fieldIndex.put("Entry name", 4);
+        fieldIndex.put("Organism ID", 5);
+        /*for (int i = 0; i < fields.length; i++) {
+          fieldIndex.put(fields[i], i); // re-instate when Uniprot fixed [help #132525]
+        }*/
+        if (!fieldIndex.containsKey("Entry") || !fieldIndex.containsKey("Protein names") ||
+            !fieldIndex.containsKey("Sequence") || !fieldIndex.containsKey("Status") ||
+            !fieldIndex.containsKey("Entry name")) {
+          throw new Exception("Unexpected UniProt response retrieved."); // ensure the required fields were found
+        }
+        continue;
+      }
+      if (fields.length < 1) {
+        continue;
+      }
+      if (fields[1].startsWith("Merged into")) { // check if the protein was demerged
+        String newAccession = fields[1].substring(12, 18);
+        Protein replacingP = proteins.get(newAccession);
+        Protein p = new Protein(fields[0]);
+        p.setStatus(STATUS.MERGED);
+        p.setProperty(PROPERTY.STATUS_INFO, fields[1]);
+        p.getReplacingProteins().add(replacingP);
+        proteins.put(fields[0], p);
+      } else if (fields[1].startsWith("Demerged into")) {
+        String accession = fields[ fieldIndex.get("Entry") ];
+        if (!accessions.contains(accession) && fields.length >= 5) {
+          accession = fields[4];
+        }
+        Protein p = new Protein(accession);
+        p.setStatus(STATUS.DEMERGED);
+        p.setProperty(PROPERTY.STATUS_INFO, fields[1]);
+        ArrayList<String> replacingAccessions = extractUniprotReplacingAccessions(fields[1]);
+        for (String acc : replacingAccessions) {
+          if (proteins.containsKey(acc)) {
+            p.getReplacingProteins().add(proteins.get(acc));
+          }
+        }
+        if (!proteins.containsKey(accession)) {
+          proteins.put(accession, p);
+        }
+      }
+      else if (fields[1].startsWith("Deleted")) {
+        Protein p = new Protein(fields[fieldIndex.get("Entry")]);
+        p.setStatus(STATUS.DELETED);
+        proteins.put(fields[0], p);
+      }
+      else {
+        if (fields.length != fieldIndex.size()) {   // make sure the line is in the expected format
+          throw new Exception("Unexpected UniProt answer retrieved. Line has a different number of fields than defined in the header: <" + lines[lineIndex] + ">");
+        }
+        String accession = (usingAccession) ? fields[fieldIndex.get("Entry")] : fields[fieldIndex.get("Entry name")];
+        String accessionIsoform = checkIsoformSequence(accessions, accession);
+        Protein p = new Protein(accession);
+        p.setName(fields[fieldIndex.get("Protein names")]);
+        p.setProperty(PROPERTY.SOURCE, (fields[fieldIndex.get("Status")].equals("reviewed")) ? "UniProt/Swiss-Prot" : "UniProt/TrEMBL");
+        p.setStatus(STATUS.ACTIVE);
+        String sequence = fields[fieldIndex.get("Sequence")];
         sequence = sequence.replaceAll("\\s", "");
-
-        // extract the protein name
-        Pattern pat = Pattern.compile(">[^|]+\\|([^|]+)\\|([^|]+)\\|([^|]*)\\|(.*)");
-
-        Matcher matcher = pat.matcher(header);
-
-        // make sure it matches
-        if (!matcher.find())
-            throw new Exception("Unexpected fasta format encountered:\n" + fasta);
-
-        String gi = matcher.group(1);
-        String source = matcher.group(2);
-        String accession = matcher.group(3);
-        String name = matcher.group(4).trim();
-        
-        String accessionVersion = null;
-        
-        if ("ref".equals(source))
-        	source = "RefSeq";
-        if (accession != null) {
-        	int index = accession.lastIndexOf('.');
-        	if (index != -1)
-        		accessionVersion = accession.substring(index + 1);
-        	// remove the version info from the accession
-        	accession = accession.replaceAll("\\.\\d+", "");
+        p.setSequenceString(sequence);
+        String organismID = fields[fieldIndex.get("Organism ID")];
+        p.setOrganismId(organismID);
+        proteins.put(accession, p);
+        if(accessionIsoform != null){
+          p.setSequenceString((isoformMapSequence.getOrDefault(accessionIsoform, sequence)));
+          p.setAccession(accessionIsoform);
+          proteins.put(accessionIsoform,p);
         }
-        
-        
-        // create the protein object
-        Protein protein = new Protein((useGi || accession == null) ? gi : accession);
-        protein.setName(name);
-        protein.setSequenceString(sequence);
-        protein.setProperty(PROPERTY.SOURCE, useGi ? "NCBI gi" : source);
-        protein.setProperty(PROPERTY.GI_NUMBER, gi);
-        if (accessionVersion != null)
-        	protein.setProperty(PROPERTY.ACCESSION_VERSION, accessionVersion);
-        
-        return protein;
+      }
     }
-    
-    /**
-     * Returns the details for the given IPI identifiers in
-     * a HashMap with the IPI identifier as key and a Protein
-     * object holding the details as value.  Uses the UniProt
-     * mapping service to map IPI entries to UniProt accessions.
-     * Then the call is passed on to getUniProtDetails.
-     *
-     * @param accessions The IPI accession to get the name for.
-     * @return A Protein object containing the protein's details.
-     * @throws Exception
-     */
-    private HashMap<String, Protein> getIpiDetails(Collection<String> accessions) throws Exception {
-        // use the uniprot mapping service to convert the ipi accessions
-        String query = "";
+    return proteins;
+  }
 
-        for (String acc : accessions)
-            query += (query.length() > 0 ? "," : "") + acc;
+  /**
+   * Extracts the replacing accession from a UniProt status
+   * line Demerged into XXXXX, XXXXX and XXXXX.
+   * @param string
+   * @return
+   */
+  private ArrayList<String> extractUniprotReplacingAccessions(String string) {
+    ArrayList<String> extractedAccessions = new ArrayList<>(2);
+    String accessions = string.substring(14); // get the accessions
+    char nextChar;
+    do {
+      String accession = accessions.substring(0, 6);
+      nextChar = accessions.charAt(6);
+      extractedAccessions.add(accession);
+      if (nextChar == ' ') {
+        accessions = accessions.substring(11);
+      }
+      else if (nextChar != '.') {
+        accessions = accessions.substring(8);
+      }
+    } while (nextChar != '.' && accessions.length() >= 7);
+    return extractedAccessions;
+  }
 
-        // map the accessions
-        String page = getPage(String.format(MAPPING_QUERY.IPI_TO_UNIPROT.getQueryString(), query));
-        String[] lines = page.split(EOL);
-
-        HashMap<String, String> uniprotToIpiMapping = new HashMap<String, String>();
-        HashMap<String, Integer> fieldMapping = new HashMap<String, Integer>();
-
-        if (lines.length<2) {
-            // no mappings found
-            return new HashMap<String, Protein>();
-        }
-
-        for (int i = 0; i < lines.length; i++) {
-            String[] fields = lines[i].split(TAB);
-
-            if (i == 0) {
-                for (int j = 0; j < fields.length; j++)
-                    fieldMapping.put(fields[j], j);
-
-                // make sure the required fields are there
-                if (!fieldMapping.containsKey("To") || !fieldMapping.containsKey("From"))
-                    throw new Exception("Unexpected response retrieved from UniProt mapping service.");
-
-                continue;
-            }
-
-            // save the mapping
-            uniprotToIpiMapping.put(fields[fieldMapping.get("To")], fields[fieldMapping.get("From")]);
-        }
-
-        // get the UniProt mappings
-        Map<String, Protein> proteins = new HashMap<String, Protein>();
-        if(uniprotToIpiMapping.size() > 0)
-            proteins = getUniProtDetails(uniprotToIpiMapping.keySet());
-
-        // create a new HashMap changing the UniProt accessions to IPI accessions
-        HashMap<String, Protein> ipiProteins = new HashMap<String, Protein>();
-
-        for (Protein p : proteins.values()) {
-            String ipiAcc = uniprotToIpiMapping.get(p.getAccession());
-            if (ipiAcc != null) {
-                p.setAccession(ipiAcc);
-                ipiProteins.put(ipiAcc, p);
-            }
-        }
-        return ipiProteins;
+  /**
+   * Returns the details for the given Ensembl identifiers in
+   * a HashMap with the Ensembl identifier as key and a Protein
+   * object holding the details as value. Uses the UniProt
+   * mapping service to map ensembl entries to UniProt accessions.
+   * Then the call is passed on to getUniProtDetails.
+   *
+   * @param accessions The Ensembl accession to get the name for.
+   * @return A Protein object containing the protein's details.
+   * @throws Exception
+   */
+  private HashMap<String, Protein> getEnsemblDetails(Collection<String> accessions) throws Exception {
+    // use the uniprot mapping service to convert the ensembl accessions
+    String query = "";
+    for (String acc : accessions) {
+      query += (query.length() > 0 ? "," : "") + acc;
     }
-    
-    /**
-     * Retrieves the protein details from UniProt from the
-     * given UniProt accessions. Returns null in case nothing
-     * was retrieved. <br />
-     * <b>Warning:</b> The function first tries to retrieve the protein details
-     * expecting them to be accessions. Only if no results are retrieved that way
-     * a second request is send interpreting the passed strings as ids. In case
-     * accessions and ids are mixed, only the proteins identified through accessions
-     * will be returned.
-     * @param accessions The UniProt accessions of the proteins.
-     * @return A Collection of Protein objects containing the proteins' details or null if the accession doesn't exist
-     * @throws Exception In case something went wrong
-     */
-    private Map<String, Protein> getUniProtDetails(Collection<String> accessions) throws Exception {
-    	// build the query string for the accessions
-
-    	String query = "";
-    	Boolean usingAccession = true;
-
-        List<String> isoforms = new ArrayList<String>();
-
-    	for (String accession : accessions) {
-    		if(accession.contains("-") || accession.contains("-")){
-                query += ((query.length() > 1) ? "%20or%20" : "") + "sequence:" + accession;
-                isoforms.add(accession);
-            }else{
-                query += ((query.length() > 1) ? "%20or%20" : "") + "accession:" + accession;
-            }
+    String page = getPage(String.format(MAPPING_QUERY.ENSEMBL_TO_UNIPROT.getQueryString(), query));
+    String[] lines = page.split(EOL);
+    HashMap<String, String> uniprotToEnsemblMapping = new HashMap<>();
+    HashMap<String, Integer> fieldMapping = new HashMap<>();
+    for (int i = 0; i < lines.length; i++) {
+      String[] fields = lines[i].split(TAB);
+      if (i == 0) {
+        for (int j = 0; j < fields.length; j++)
+          fieldMapping.put(fields[j], j);
+        if (!fieldMapping.containsKey("To") || !fieldMapping.containsKey("From")) {
+          throw new Exception("Unexpected response retrieved from UniProt mapping service.");
         }
-
-    	String url = String.format(DETAILS_QUERY.UNIPROT.getQueryString(), query);
-    	//System.out.println(url);
-
-    	// get the page
-        String page = getPage(url);
-        if ("".equals(page.trim())) {
-        	// try with uniprot ids
-        	usingAccession = false;
-            page = getPage(String.format(DETAILS_QUERY.UNIPROT.getQueryString(), query.replace("accession:", "mnemonic:")));
-        }
-        if(page.equals("")){
-            return Collections.emptyMap();
-        }
-
-        String[] lines = page.split(EOL);
-
-        if (lines.length < 2) {
-            return Collections.emptyMap();
-        }
-
-        //retrieve the isoform sequences for each isoforms ID
-        Map<String,String> isoformMapSequence = new HashMap<String, String>();
-        if(isoforms.size() > 0)
-            isoformMapSequence = getFastaSequencePage(isoforms);
-
-        HashMap<String, Integer> fieldIndex = new HashMap<String, Integer>();
-        HashMap<String, Protein> proteins = new HashMap<String, Protein>();
-        
-        // create the retrieved proteins
-        for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-        	 String[] fields = lines[lineIndex].split(TAB);
-        	// if it's the first line build the field index
-        	if (lineIndex == 0) {
-        		for (int i = 0; i < fields.length; i++)
-        			fieldIndex.put(fields[i], i);
-        		
-        		// make sure the required fields were found
-        		if (!fieldIndex.containsKey("Entry") || !fieldIndex.containsKey("Protein names") ||
-        			!fieldIndex.containsKey("Sequence") || !fieldIndex.containsKey("Status") ||
-        			!fieldIndex.containsKey("Entry name"))
-        			throw new Exception("Unexpected UniProt response retrieved.");
-        		
-        		continue;
-        	}
-
-        	if (fields.length < 1)
-        		continue;
-        	
-        	// check if the protein was demerged
-        	if (fields[1].startsWith("Merged into")) {
-        		// extract the new accession
-        		String newAccession = fields[1].substring(12, 18);
-        		// get the protein
-        		Protein replacingP = proteins.get(newAccession);
-        		// create the current protein
-        		Protein p = new Protein(fields[0]);
-        		
-        		// set the status
-        		p.setStatus(STATUS.MERGED);
-        		p.setProperty(PROPERTY.STATUS_INFO, fields[1]);
-        		p.getReplacingProteins().add(replacingP);
-        		
-        		proteins.put(fields[0], p);
-        	}
-        	else if (fields[1].startsWith("Demerged into")) {
-        		// check if the accession or id should be used (not clear for ids)
-        		String accession = fields[ fieldIndex.get("Entry") ];
-        		
-        		if (!accessions.contains(accession) && fields.length >= 5) {
-        			accession = fields[4];
-        		}
-        		
-        		// create a new protein
-        		Protein p = new Protein(accession);
-        		
-        		// set the status
-        		p.setStatus(STATUS.DEMERGED);
-        		p.setProperty(PROPERTY.STATUS_INFO, fields[1]);
-        		
-        		// add the replacing proteins
-        		ArrayList<String> replacingAccessions = extractUniprotReplacingAccessions(fields[1]);
-        		for (String acc : replacingAccessions) {
-        			if (proteins.containsKey(acc))
-        				p.getReplacingProteins().add(proteins.get(acc));
-        		}	
-        		
-        		if (!proteins.containsKey(accession))
-        			proteins.put(accession, p);
-        	}
-        	else if (fields[1].startsWith("Deleted")) {
-        		// create a new protein
-        		Protein p = new Protein(fields[fieldIndex.get("Entry")]);
-        		
-        		p.setStatus(STATUS.DELETED);
-        		
-        		proteins.put(fields[0], p);
-        	}
-        	else {
-        		// make sure the line is in the expected format
-            	if (fields.length != fieldIndex.size())
-            		throw new Exception("Unexpected UniProt answer retrieved. Line has a different number of fields than defined in the header: <" + lines[lineIndex] + ">");
-            	
-            	// create the protein object
-            	String accession = (usingAccession) ? fields[fieldIndex.get("Entry")] : fields[fieldIndex.get("Entry name")];
-            	String accessionIsoform = checkIsoformSequence(accessions, accession);
-
-            	Protein p = new Protein(accession);
-            	p.setName(fields[fieldIndex.get("Protein names")]);
-            	p.setProperty(PROPERTY.SOURCE, (fields[fieldIndex.get("Status")].equals("reviewed")) ? "UniProt/Swiss-Prot" : "UniProt/TrEMBL");
-            	p.setStatus(STATUS.ACTIVE);
-            	
-            	String sequence = fields[fieldIndex.get("Sequence")];
-            	sequence = sequence.replaceAll("\\s", "");
-            	
-            	p.setSequenceString(sequence);
-
-                String organismID = fields[fieldIndex.get("Organism ID")];
-                p.setOrganismId(organismID);
-            	
-            	proteins.put(accession, p);
-                if(accessionIsoform != null){
-                    p.setSequenceString((isoformMapSequence.containsKey(accessionIsoform)?isoformMapSequence.get(accessionIsoform):sequence));
-                    p.setAccession(accessionIsoform);
-                    proteins.put(accessionIsoform,p);
-                }
-        	}
-        }
-        
-        // return the proteins
-        return proteins;
+        continue;
+      }
+      uniprotToEnsemblMapping.put(fields[fieldMapping.get("To")], fields[fieldMapping.get("From")]);
     }
-    
-    /**
-     * Extracts the replacing accession from a UniProt status
-     * line Demerged into XXXXX, XXXXX and XXXXX.
-     * @param string
-     * @return
-     */
-    private ArrayList<String> extractUniprotReplacingAccessions(String string) {
-    	ArrayList<String> extractedAccessions = new ArrayList<String>(2);
-    	
-    	// get the accessions
-    	String accessions = string.substring(14);
-    	char nextChar;
-    	
-    	do {
-    		String accession = accessions.substring(0, 6);
-    		nextChar = accessions.charAt(6);
-    		
-    		extractedAccessions.add(accession);
-    		
-    		if (nextChar == ' ')
-    			accessions = accessions.substring(11);
-    		else if (nextChar != '.')
-    			accessions = accessions.substring(8);
-    	} while (nextChar != '.' && accessions.length() >= 7);
-    	
-		return extractedAccessions;
-	}
-
-	/**
-     * Returns the details for the given Ensembl identifiers in
-     * a HashMap with the Ensembl identifier as key and a Protein
-     * object holding the details as value. Uses the UniProt
-     * mapping service to map ensembl entries to UniProt accessions.
-     * Then the call is passed on to getUniProtDetails.
-     *
-     * @param accessions The Ensembl accession to get the name for.
-     * @return A Protein object containing the protein's details.
-     * @throws Exception
-     */
-    private HashMap<String, Protein> getEnsemblDetails(Collection<String> accessions) throws Exception {
-    	// use the uniprot mapping service to convert the ensembl accessions
-    	String query = "";
-    	
-    	for (String acc : accessions)
-    		query += (query.length() > 0 ? "," : "") + acc;
-    	
-    	// map the accessions
-    	String page = getPage(String.format(MAPPING_QUERY.ENSEMBL_TO_UNIPROT.getQueryString(), query));
-    	String[] lines = page.split(EOL);
-    	
-    	HashMap<String, String> uniprotToEnsemblMapping = new HashMap<String, String>();
-    	HashMap<String, Integer> fieldMapping = new HashMap<String, Integer>();
-    	
-    	for (int i = 0; i < lines.length; i++) {
-    		String[] fields = lines[i].split(TAB);
-    		
-    		if (i == 0) {
-    			for (int j = 0; j < fields.length; j++)
-    				fieldMapping.put(fields[j], j);
-    			
-    			// make sure the required fields are there
-    			if (!fieldMapping.containsKey("To") || !fieldMapping.containsKey("From"))
-    				throw new Exception("Unexpected response retrieved from UniProt mapping service.");
-    			
-    			continue;
-    		}
-    		
-    		// save the mapping
-    		uniprotToEnsemblMapping.put(fields[fieldMapping.get("To")], fields[fieldMapping.get("From")]);
-    	}
-    	
-    	// get the UniProt mappings
-        Map<String, Protein> proteins = new HashMap<String, Protein>();
-        if(uniprotToEnsemblMapping.size() > 0 )
-    	   proteins = getUniProtDetails(uniprotToEnsemblMapping.keySet());
-    	
-    	// create a new HashMap changing the UniProt accessions to ENSEMBL accessions
-    	HashMap<String, Protein> ensemblProteins = new HashMap<String, Protein>();
-    	
-    	for (Protein p : proteins.values()) {
-    		String ensemblAcc = uniprotToEnsemblMapping.get(p.getAccession());
-    		
-    		if (ensemblAcc == null)
-    			continue;
-    		
-    		p.setAccession(ensemblAcc);
-    		
-    		ensemblProteins.put(ensemblAcc, p);
-    	}
-    	
-    	return ensemblProteins;
+    Map<String, Protein> proteins = new HashMap<>();
+    if(uniprotToEnsemblMapping.size() > 0 ) {
+      proteins = getUniProtDetails(uniprotToEnsemblMapping.keySet());
     }
-    
-    /**
-     * Retrieves the page at the given location and parses the
-     * retrieved tab-delimited table.
-     * @param location
-     * @return
-     * @throws Exception
-     */
-    private ArrayList<HashMap<String, String>> getTable(String location) throws Exception {
-    	// get the page
-    	String page = getPage(location);
-    	
-    	HashMap<String, Integer> header = new HashMap<String, Integer>();
-    	ArrayList<HashMap<String, String>> table = new ArrayList<HashMap<String,String>>();
-    	
-    	String[] lines = page.split(EOL);
-    	
-    	for (int i = 0; i < lines.length; i++) {
-    		String[] fields = lines[i].split(TAB);
-    		
-    		// build the header if it's the first line
-    		if (i == 0) {
-    			for (int j = 0; j < fields.length; j++)
-    				header.put(fields[j], j);
-    			
-    			continue;
-    		}
-    		
-    		// parse the line
-    		HashMap<String, String> line = new HashMap<String, String>(header.size());
-    		
-    		for (String headerField : header.keySet()) {
-    			int nFieldPot = header.get(headerField);
-    			
-    			if (nFieldPot >= 0 && nFieldPot < fields.length)
-    				line.put(headerField, fields[nFieldPot]);
-    		}
-    		
-    		table.add(line);
-    	}
-    	
-    	return table;
+    HashMap<String, Protein> ensemblProteins = new HashMap<>();
+    for (Protein p : proteins.values()) {
+      String ensemblAcc = uniprotToEnsemblMapping.get(p.getAccession());
+      if (ensemblAcc == null) {
+        continue;
+      }
+      p.setAccession(ensemblAcc);
+      ensemblProteins.put(ensemblAcc, p);
     }
+    return ensemblProteins;
+  }
 
-    /**
-     * Gets the page from the given address. Returns the
-     * retrieved page as a string.
-     *
-     * @param urlString The address of the resource to retrieve.
-     * @return The page as a String
-     * @throws Exception Thrown on any problem.
-     */
-    private String getPage(String urlString) throws Exception {
-        // check if the page is cached
-        if (pageBuffer.containsKey(urlString))
-            return pageBuffer.get(urlString);
+  /**
+   * Gets the page from the given address. Returns the
+   * retrieved page as a string.
+   *
+   * @param urlString The address of the resource to retrieve.
+   * @return The page as a String
+   * @throws Exception Thrown on any problem.
+   */
+  private String getPage(String urlString) throws Exception {
+    URL url = new URL(urlString);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.connect();
+    BufferedReader in = null;
+    StringBuilder page = new StringBuilder();
+    try {
+      in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+      String line;
+      while ((line = in.readLine()) != null) {
+        page.append(line);
+        page.append("\n");
+      }
+    } catch (IOException ioe) {
+      logger.warn("Failed to read web page");
+    } finally {
+      if (in != null) {
+        in.close();
+      }
+    }
+    return page.toString();
+  }
 
-        // create the url
-        URL url = new URL(urlString);
-
-        // send the request
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-
-        connection.connect();
-
-        // get the page
-        BufferedReader in = null;
-        StringBuilder page = new StringBuilder();
-        try {
-            in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-
-            String line;
-            while ((line = in.readLine()) != null) {
-                page.append(line);
-                page.append("\n");
-            }
-        } catch (IOException ioe) {
-            logger.warn("Failed to read web page");
-        } finally {
-            if (in != null) {
-                in.close();
-            }
+  /**
+   * The only way to retrieve the isoforms sequences is one-by-one. The current method
+   * get a Map of isoform accessions and retrieve
+   * @param isoforms a list of isoforms
+   * @return a map of isoform accessions and its sequence
+   */
+  private Map<String, String> getFastaSequencePage(List<String> isoforms) throws Exception {
+    Map<String, String> isoformSequences = new HashMap<>();
+    for(String accession : isoforms){
+      String query = accession + ".fasta";
+      String url = String.format(DETAILS_QUERY.UNIPROT_FASTA.getQueryString(), query);
+      String page = getPage(url);
+      String[] lines = page.split(EOL);
+      if (!page.equals("") && lines.length > 2) { // if there's only one line or the page was empty no protein names were retrieved
+        StringBuilder sequence = new StringBuilder();
+        for(int i = 1; i < lines.length; i++){
+          sequence.append(lines[i]);
         }
-
-        return page.toString();
+        isoformSequences.put(accession, sequence.toString());
+      }
     }
+    return isoformSequences;
+  }
 
-    /**
-     * The only way to retrieve the isoforms sequences is one-by-one. The current method
-     * get a Map of isoform accessions and retrieve
-     * @param isoforms
-     * @return
-     */
-    private Map<String, String> getFastaSequencePage(List<String> isoforms) throws Exception {
-
-        Map<String, String> isoformSequences = new HashMap<String, String>();
-
-        for(String accession: isoforms){
-           String query = accession + ".fasta";
-            String url = String.format(DETAILS_QUERY.UNIPROT_FASTA.getQueryString(), query);
-            // System.out.println(url);
-            // get the page
-            String page = getPage(url);
-            String[] lines = page.split(EOL);
-
-            // if there's only one line or the page was empty no protein names were retrieved
-            if (!page.equals("") && lines.length > 2) {
-                String sequence = "";
-                for(int i = 1; i < lines.length; i++){
-                    sequence = sequence + lines[i];
-                }
-               isoformSequences.put(accession,sequence);
-            }
-        }
-        return isoformSequences;
+  private String checkIsoformSequence(Collection<String> accessions, String accession){
+    String isoform = null;
+    for(String accessionString : accessions){
+      if(accessionString.contains(accession)){
+        isoform = accessionString;
+        break;
+      }
     }
+    return isoform;
+  }
 
-    private String checkIsoformSequence(Collection<String> accessions, String accession){
-        String isoform = null;
-        for(String accessionString: accessions){
-            if(accessionString.contains(accession)){
-                isoform = accessionString;
-                break;
-            }
-        }
-        return isoform;
+  /**
+   * From a protein Ids check all the services (Uniprot, EntrezGene) to know if the web services
+   * are available.
+   *
+   * @return true if Uniprot is available, false otherwise
+   */
+  public static boolean checkUniprotService(){
+    boolean servicesAvailable = false;
+    Collection<String> uniprotIds = new ArrayList<>();
+    uniprotIds.add(UNIPROT_PROTEIN);
+    ProteinDetailFetcher proteinDetailFetcher = new ProteinDetailFetcher();
+    try{
+      HashMap<String, Protein> uniprotDetails = proteinDetailFetcher.getProteinDetails(uniprotIds);
+      if( uniprotDetails != null && !uniprotDetails.isEmpty()) {
+        servicesAvailable = true;
+      }
+    } catch (Exception e) {
+      logger.error("There is no internet connection", e);
     }
-
-    /**
-     * From a protein Ids check all the services (Uniprot, EntrezGene) to know if the web services
-     * are available.
-     *
-     * @return
-     */
-    public static boolean checkUniprotService(){
-        boolean servicesAvailable = false;
-        Collection<String> uniprotIds = new ArrayList<String>();
-        uniprotIds.add(UNIPROT_PROTEIN);
-        ProteinDetailFetcher proteinDetailFetcher = new ProteinDetailFetcher();
-        try{
-        HashMap<String, Protein> uniprotDetails = proteinDetailFetcher.getProteinDetails(uniprotIds);
-        if( uniprotDetails != null && !uniprotDetails.isEmpty())
-            return true;
-        }catch (Exception e) {
-            logger.error("There is no internet connection", e);
-            return false;
-        }
-        return servicesAvailable;
-    }
+    return servicesAvailable;
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/tools/protein_details_fetcher/model/Protein.java
+++ b/src/main/java/uk/ac/ebi/pride/tools/protein_details_fetcher/model/Protein.java
@@ -1,5 +1,7 @@
 package uk.ac.ebi.pride.tools.protein_details_fetcher.model;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,7 +16,7 @@ import java.util.Set;
  * Date: 08/06/11
  * Time: 16:42
  */
-@SuppressWarnings("serial")
+
 public class Protein implements Serializable {
     public enum STATUS {UNKNOWN, ACTIVE, DELETED, CHANGED, DEMERGED, MERGED, ERROR};
     /**
@@ -23,12 +25,12 @@ public class Protein implements Serializable {
      * @author jg
      *
      */
-    public enum PROPERTY{STATUS_INFO, GI_NUMBER, SOURCE, ERROR_STRING, ACCESSION_VERSION};
+    public enum PROPERTY{STATUS_INFO, SOURCE, ERROR_STRING, ACCESSION_VERSION};
     /**
      * The protein's properties.
      */
-    private HashMap<PROPERTY, String> properties = new HashMap<Protein.PROPERTY, String>();
-	/**
+    private HashMap<PROPERTY, String> properties = new HashMap<>();
+    /**
      * Human readable name for the protein
      */
     private String name = null;
@@ -51,14 +53,13 @@ public class Protein implements Serializable {
 
     private String organismId = null;
 
-    private List<Protein> replacingProteins = new ArrayList<Protein>();
+    private List<Protein> replacingProteins = new ArrayList<>();
 
 
     public Protein(String accession) {
         if (accession == null || "".equals(accession.trim())) {
             throw new IllegalArgumentException("Protein accession cannot be NULL");
         }
-
         this.accession = accession;
     }
 
@@ -83,27 +84,31 @@ public class Protein implements Serializable {
     }
 
     public void setSequenceString(String sequence) {
-        this.sequenceString = sequence == null ? sequence : sequence.toUpperCase();
+        if (!StringUtils.isEmpty(sequence)) {
+            this.sequenceString = sequence.toUpperCase();
+        } else {
+            this.sequenceString = null;
+        }
     }
 
     public STATUS getStatus() {
-    	return status;
+        return status;
     }
 
     public void setStatus(STATUS status) {
         this.status = status;
     }
-	
-	public List<Protein> getReplacingProteins() {
-		return replacingProteins;
-	}
 
-	public String getSubSequenceString(int start, int stop) {
+    public List<Protein> getReplacingProteins() {
+        return replacingProteins;
+    }
+
+    public String getSubSequenceString(int start, int stop) {
+        String result = null;
         if (sequenceString != null && sequenceString.length() >= stop && start >= 1 && start <= stop) {
-            return this.sequenceString.substring(start - 1, stop);
-        } else {
-            return null;
+            result =  this.sequenceString.substring(start - 1, stop);
         }
+        return result;
     }
 
     /**
@@ -136,30 +141,30 @@ public class Protein implements Serializable {
      * @return  Set<Integer>    starting positions
      */
     public Set<Integer> searchStartingPosition(String subSeq) {
-        Set<Integer> pos = new HashSet<Integer>();
-
+        Set<Integer> position = new HashSet<>();
         if (sequenceString != null && subSeq != null) {
             int previousIndex = -1;
-            int index = -1;
-
-            while((index = (previousIndex == -1 ? sequenceString.indexOf(subSeq) : sequenceString.indexOf(subSeq, previousIndex + 1))) > -1) {
-                pos.add(index);
+            int index;
+            while((index = (previousIndex == -1 ?
+                sequenceString.indexOf(subSeq) :
+                sequenceString.indexOf(subSeq, previousIndex + 1)))
+                > -1) {
+                position.add(index);
                 previousIndex = index;
             }
         }
-
-        return pos;
+        return position;
     }
-    
+
     /**
      * Sets the given property.
      * @param property
      * @param value
      */
     public void setProperty(PROPERTY property, String value) {
-    	properties.put(property, value);
+        properties.put(property, value);
     }
-    
+
     /**
      * Returns the value of the specified property
      * or null in case it wasn't set.
@@ -167,7 +172,11 @@ public class Protein implements Serializable {
      * @return The property's value as String or null if it wasn't set.
      */
     public String getProperty(PROPERTY property) {
-    	return properties.get(property);
+        return properties.get(property);
+    }
+
+    public boolean hasProperty(PROPERTY property) {
+        return properties.containsKey(property);
     }
 
     public String getOrganismId() {

--- a/src/main/java/uk/ac/ebi/pride/tools/protein_details_fetcher/util/ProteinAccessionPattern.java
+++ b/src/main/java/uk/ac/ebi/pride/tools/protein_details_fetcher/util/ProteinAccessionPattern.java
@@ -12,165 +12,134 @@ import java.util.regex.Pattern;
  * Time: 10:12:32
  */
 public enum ProteinAccessionPattern {
-    /**
-     * Ensembl accession
-     */
-    ENSEMBL(Pattern.compile("ENSP[A-Z,0-9]+"),
-            new MessageFormat("http://www.ensembl.org/common/psychic?site=&species=&q={0}")),
-    /**
-     * FlyBase identifier numbers have the general form FBxxnnnnnnn where xx is an
-     * alphabetical code for the identifier class and nnnnnnn is a 7 digit number, padded with leading zeros.
-     */
-    FLYBASE(Pattern.compile("FB[a-z,A-Z]{2}[\\d]{7}"),
-            new MessageFormat("http://flybase.bio.indiana.edu/cgi-bin/uniq.html?species=Dmel&field=all&db=fbgn&caller=quicksearch&context={0}")),
-    /**
-     * IPI accession, service has been discontinued.
-     * URL is now deprecated.
-     */
-    IPI(Pattern.compile("IPI.+"),
-            new MessageFormat("{0}")),
-    /**
-     * RefSeq accession numbers can be distinguished from GenBank accessions by their distinct prefix format of
-     * 2 characters followed by an underscore character ('_'). For example, a RefSeq protein accession is NP_015325.
-     */
-    REFSEQ(Pattern.compile("[A-Z]{2}_[\\d]+(\\.\\d+)?"),
-            new MessageFormat("http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?db=protein&val={0}")),
-    /**
-     * GI number should be all numbers
-      */
-    GI(Pattern.compile("[\\d]+"),
-            new MessageFormat("http://www.ncbi.nlm.nih.gov/protein/{0}")),
-    /**
-     * SGD for example: S000005574
-     */
-    SGD(Pattern.compile("S[\\d]{9}"),
-            new MessageFormat("http://db.yeastgenome.org/cgi-bin/locus.pl?locus={0}")),
-    /**
-     * This will match both uniprot accession and uniprot isoform accession
-     */
-    SWISSPROT(Pattern.compile("(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9][A-Z][A-Z0-9]{2}[0-9])(-[0-9]+)?"),
-            new MessageFormat("http://www.uniprot.org/entry/{0}")),
+  /**
+   * Ensembl accession
+   */
+  ENSEMBL(Pattern.compile("ENSP[A-Z,0-9]+"),
+      new MessageFormat("http://www.ensembl.org/common/psychic?site=&species=&q={0}")),
+  /**
+   * FlyBase identifier numbers have the general form FBxxnnnnnnn where xx is an
+   * alphabetical code for the identifier class and nnnnnnn is a 7 digit number, padded with leading zeros.
+   */
+  FLYBASE(Pattern.compile("FB[a-z,A-Z]{2}[\\d]{7}"),
+      new MessageFormat("http://flybase.bio.indiana.edu/cgi-bin/uniq.html?species=Dmel&field=all&db=fbgn&caller=quicksearch&context={0}")),
+  /**
+   * RefSeq accession numbers can be distinguished from GenBank accessions by their distinct prefix format of
+   * 2 characters followed by an underscore character ('_'). For example, a RefSeq protein accession is NP_015325.
+   */
+  REFSEQ(Pattern.compile("[A-Z]{2}_[\\d]+(\\.\\d+)?"),
+      new MessageFormat("http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?db=protein&val={0}")),
+  /**
+   * SGD for example: S000005574
+   */
+  SGD(Pattern.compile("S[\\d]{9}"),
+      new MessageFormat("http://db.yeastgenome.org/cgi-bin/locus.pl?locus={0}")),
+  /**
+   * This will match both uniprot accession and uniprot isoform accession
+   */
+  SWISSPROT(Pattern.compile("(?:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9][A-Z][A-Z0-9]{2}[0-9])(-[0-9]+)?"),
+      new MessageFormat("http://www.uniprot.org/entry/{0}")),
 
-    /**
-     * This will match SWISSPROT entry name
-     */
-    SWISSPROT_ENTRY_NAME(Pattern.compile("[a-zA-Z0-9]{1,5}_[a-zA-Z0-9]{1,5}"),
-            new MessageFormat("http://www.uniprot.org/entry/{0}")),
-    /**
-     * TAIR's accession is normally in the format of AT5G25950.1
-     */
-    TAIR_ARABIDOPSIS(Pattern.compile("AT[1-9,A-Z]G.*"),
-            new MessageFormat("http://www.arabidopsis.org/servlets/Search?sub_type=protein&type=general&search_action=detail&method=1&name={0}")),
-    /**
-     * Wormbase accession, for example: WP:CE28239
-     */
-    WORMBASE(Pattern.compile("WP:.+"),
-            new MessageFormat("http://www.wormbase.org/db/seq/protein?name={0};class=Protein")),
-    /**
-     * UNIPARC
-     */
-    UNIPARC(Pattern.compile("UPI.+"),
-            new MessageFormat("http://www.uniprot.org/uniparc/{0}")),
-    /**
-     * EMBL
-     */
-    EMBL(Pattern.compile("[A-Z]{3}[0-9]{5}\\.[0-9]+"),
-            new MessageFormat("http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[emblcds-ID:''{0}'']"));
+  /**
+   * This will match SWISSPROT entry name
+   */
+  SWISSPROT_ENTRY_NAME(Pattern.compile("[a-zA-Z0-9]{1,5}_[a-zA-Z0-9]{1,5}"),
+      new MessageFormat("http://www.uniprot.org/entry/{0}")),
+  /**
+   * TAIR's accession is normally in the format of AT5G25950.1
+   */
+  TAIR_ARABIDOPSIS(Pattern.compile("AT[1-9,A-Z]G.*"),
+      new MessageFormat("http://www.arabidopsis.org/servlets/Search?sub_type=protein&type=general&search_action=detail&method=1&name={0}")),
+  /**
+   * Wormbase accession, for example: WP:CE28239
+   */
+  WORMBASE(Pattern.compile("WP:.+"),
+      new MessageFormat("http://www.wormbase.org/db/seq/protein?name={0};class=Protein")),
+  /**
+   * UNIPARC
+   */
+  UNIPARC(Pattern.compile("UPI.+"),
+      new MessageFormat("http://www.uniprot.org/uniparc/{0}")),
+  /**
+   * EMBL
+   */
+  EMBL(Pattern.compile("[A-Z]{3}[0-9]{5}\\.[0-9]+"),
+      new MessageFormat("http://srs.ebi.ac.uk/srsbin/cgi-bin/wgetz?-e+[emblcds-ID:''{0}'']"));
 
-    private Pattern idPattern;
-    private MessageFormat urlPattern;
+  private Pattern idPattern;
+  private MessageFormat urlPattern;
 
-    private ProteinAccessionPattern(Pattern idPattern, MessageFormat urlPattern) {
-        this.idPattern = idPattern;
-        this.urlPattern = urlPattern;
-    }
+  ProteinAccessionPattern(Pattern idPattern, MessageFormat urlPattern) {
+    this.idPattern = idPattern;
+    this.urlPattern = urlPattern;
+  }
 
-    public Pattern getIdPattern() {
-        return idPattern;
-    }
+  public Pattern getIdPattern() {
+    return idPattern;
+  }
 
-    public MessageFormat getUrlPattern() {
-        return urlPattern;
-    }
+  public MessageFormat getUrlPattern() {
+    return urlPattern;
+  }
 
-    /**
-     * Check whether it is a swissprot accession
-     *
-     * @param acc protein accession
-     * @return boolean true if it's a swissprot accession
-     */
-    public static boolean isSwissprotAccession(String acc) {
-        return isMatchAccession(SWISSPROT.getIdPattern(), acc);
-    }
+  /**
+   * Check whether it is a swissprot accession
+   *
+   * @param acc protein accession
+   * @return boolean true if it's a swissprot accession
+   */
+  public static boolean isSwissprotAccession(String acc) {
+    return isMatchAccession(SWISSPROT.getIdPattern(), acc);
+  }
 
-    /**
-     * Check whether it is a swissprot entry name
-     * @param name  entry name
-     * @return boolean  true if tis a swissprot entry name
-     */
-    public static boolean isSwissprotEntryName(String name) {
-        return isMatchAccession(SWISSPROT_ENTRY_NAME.getIdPattern(), name);
-    }
+  /**
+   * Check whether it is a swissprot entry name
+   * @param name  entry name
+   * @return boolean  true if tis a swissprot entry name
+   */
+  public static boolean isSwissprotEntryName(String name) {
+    return isMatchAccession(SWISSPROT_ENTRY_NAME.getIdPattern(), name);
+  }
 
-    /**
-     * Check whether it is a Uniparc accession
-     *
-     * @param acc protein accession
-     * @return boolean true if it's a swissprot accession
-     */
-    public static boolean isUniparcAccession(String acc) {
-        return isMatchAccession(UNIPARC.getIdPattern(), acc);
-    }
+  /**
+   * Check whether it is a Uniparc accession
+   *
+   * @param acc protein accession
+   * @return boolean true if it's a swissprot accession
+   */
+  public static boolean isUniparcAccession(String acc) {
+    return isMatchAccession(UNIPARC.getIdPattern(), acc);
+  }
 
-    /**
-     * Check whether it is a REFSEQ accession
-     *
-     * @param acc protein accession
-     * @return boolean true if it's a REFSEQ accession
-     */
-    public static boolean isRefseqAccession(String acc) {
-        return isMatchAccession(REFSEQ.getIdPattern(), acc);
-    }
+  /**
+   * Check whether it is a REFSEQ accession
+   *
+   * @param acc protein accession
+   * @return boolean true if it's a REFSEQ accession
+   */
+  public static boolean isRefseqAccession(String acc) {
+    return isMatchAccession(REFSEQ.getIdPattern(), acc);
+  }
 
-    /**
-     * Check whether it is a GI accession.
-     *
-     * @param acc   protein accession
-     * @return  boolean true if it is a GI accession.
-     */
-    public static boolean isGIAccession(String acc) {
-        return isMatchAccession(GI.getIdPattern(), acc);
-    }
+  /**
+   * Check whether it is a ensembl accession
+   *
+   * @param acc protein accession
+   * @return boolean true if it's a swissprot accession
+   */
+  public static boolean isEnsemblAccession(String acc) {
+    return isMatchAccession(ENSEMBL.getIdPattern(), acc);
+  }
 
-    /**
-     * Check whether it is a IPI accession
-     *
-     * @param acc protein accession
-     * @return boolean true if it's a IPI accession
-     */
-    public static boolean isIPIAccession(String acc) {
-        return isMatchAccession(IPI.getIdPattern(), acc);
-    }
-
-    /**
-     * Check whether it is a ensembl accession
-     *
-     * @param acc protein accession
-     * @return boolean true if it's a swissprot accession
-     */
-    public static boolean isEnsemblAccession(String acc) {
-        return isMatchAccession(ENSEMBL.getIdPattern(), acc);
-    }
-
-    /**
-     * Check whether a protein accession matches the given pattern
-     *
-     * @param pattern protein accession pattern
-     * @param acc     protein accession
-     * @return boolean  true if matched
-     */
-    private static boolean isMatchAccession(Pattern pattern, String acc) {
-        Matcher matcher = pattern.matcher(acc);
-        return matcher.matches();
-    }
+  /**
+   * Check whether a protein accession matches the given pattern
+   *
+   * @param pattern protein accession pattern
+   * @param acc     protein accession
+   * @return boolean  true if matched
+   */
+  private static boolean isMatchAccession(Pattern pattern, String acc) {
+    Matcher matcher = pattern.matcher(acc);
+    return matcher.matches();
+  }
 }

--- a/src/test/java/uk/ac/ebi/pride/tools/protein_details_fetcher/ProteinDetailFetcherTest.java
+++ b/src/test/java/uk/ac/ebi/pride/tools/protein_details_fetcher/ProteinDetailFetcherTest.java
@@ -12,230 +12,163 @@ import junit.framework.TestCase;
 
 public class ProteinDetailFetcherTest extends TestCase {
 
-	public void testGetProteinDetails() {
-		ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
-	
-		ArrayList<String> accessions = new ArrayList<String>(3);
-		accessions.add("P12345");
-		accessions.add("P12346");
-		accessions.add("P12347");
-		accessions.add("TRFE_RAT"); // id for P12346
-		accessions.add("IPI00003881");
-		accessions.add("ENSP00000263100");
-		accessions.add("NP_004788");
-		accessions.add("120666");
-		accessions.add("157327346");
-		
-		try {
-			Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
-			
-			assertEquals(9, proteins.size());
-			
-			Protein p = proteins.get("P12345");
-			assertNotNull(p);
-			assertEquals("P12345", p.getAccession());
-			assertEquals("Aspartate aminotransferase, mitochondrial (mAspAT) (EC 2.6.1.1) (EC 2.6.1.7) (Fatty acid-binding protein) (FABP-1) (Glutamate oxaloacetate transaminase 2) (Kynurenine aminotransferase 4) (Kynurenine aminotransferase IV) (Kynurenine--oxoglutarate transaminase 4) (Kynurenine--oxoglutarate transaminase IV) (Plasma membrane-associated fatty acid-binding protein) (FABPpm) (Transaminase A)", p.getName());
-			assertEquals("MALLHSARVLSGVASAFHPGLAAAASARASSWWAHVEMGPPDPILGVTEAYKRDTNSKKMNLGVGAYRDDNGKPYVLPSVRKAEAQIAAKGLDKEYLPIGGLAEFCRASAELALGENSEVVKSGRFVTVQTISGTGALRIGASFLQRFFKFSRDVFLPKPSWGNHTPIFRDAGMQLQSYRYYDPKTCGFDFTGALEDISKIPEQSVLLLHACAHNPTGVDPRPEQWKEIATVVKKRNLFAFFDMAYQGFASGDGDKDAWAVRHFIEQGINVCLCQSYAKNMGLYGERVGAFTVICKDADEAKRVESQLKILIRPMYSNPPIHGARIASTILTSPDLRKQWLQEVKGMADRIIGMRTQLVSNLKKEGSTHSWQHITDQIGMFCFTGLKPEQVERLTKEFSIYMTKDGRISVAGVTSGNVGYLAHAIHQVTK", p.getSequenceString());
-			
-			p = proteins.get("TRFE_RAT");
-			assertNotNull(p);
-			assertEquals("TRFE_RAT", p.getAccession());
-			assertEquals("Serotransferrin (Transferrin) (Beta-1 metal-binding globulin) (Liver regeneration-related protein LRRG03) (Siderophilin)", p.getName());
-			assertEquals("MRFAVGALLACAALGLCLAVPDKTVKWCAVSEHENTKCISFRDHMKTVLPADGPRLACVKKTSYQDCIKAISGGEADAITLDGGWVYDAGLTPNNLKPVAAEFYGSLEHPQTHYLAVAVVKKGTDFQLNQLQGKKSCHTGLGRSAGWIIPIGLLFCNLPEPRKPLEKAVASFFSGSCVPCADPVAFPQLCQLCPGCGCSPTQPFFGYVGAFKCLRDGGGDVAFVKHTTIFEVLPQKADRDQYELLCLDNTRKPVDQYEDCYLARIPSHAVVARNGDGKEDLIWEILKVAQEHFGKGKSKDFQLFGSPLGKDLLFKDSAFGLLRVPPRMDYRLYLGHSYVTAIRNQREGVCPEGSIDSAPVKWCALSHQERAKCDEWSVSSNGQIECESAESTEDCIDKIVNGEADAMSLDGGHAYIAGQCGLVPVMAENYDISSCTNPQSDVFPKGYYAVAVVKASDSSINWNNLKGKKSCHTGVDRTAGWNIPMGLLFSRINHCKFDEFFSQGCAPGYKKNSTLCDLCIGPAKCAPNNREGYNGYTGAFQCLVEKGDVAFVKHQTVLENTNGKNTAAWAKDLKQEDFQLLCPDGTKKPVTEFATCHLAQAPNHVVVSRKEKAARVSTVLTAQKDLFWKGDKDCTGNFCLFRSSTKDLLFRDDTKCLTKLPEGTTYEEYLGAEYLQAVGNIRKCSTSRLLEACTFHKS", p.getSequenceString());
-			
-			p = proteins.get("P12346");
-			assertNotNull(p);
-			assertEquals("P12346", p.getAccession());
-			assertEquals("Serotransferrin (Transferrin) (Beta-1 metal-binding globulin) (Liver regeneration-related protein LRRG03) (Siderophilin)", p.getName());
-			assertEquals("MRFAVGALLACAALGLCLAVPDKTVKWCAVSEHENTKCISFRDHMKTVLPADGPRLACVKKTSYQDCIKAISGGEADAITLDGGWVYDAGLTPNNLKPVAAEFYGSLEHPQTHYLAVAVVKKGTDFQLNQLQGKKSCHTGLGRSAGWIIPIGLLFCNLPEPRKPLEKAVASFFSGSCVPCADPVAFPQLCQLCPGCGCSPTQPFFGYVGAFKCLRDGGGDVAFVKHTTIFEVLPQKADRDQYELLCLDNTRKPVDQYEDCYLARIPSHAVVARNGDGKEDLIWEILKVAQEHFGKGKSKDFQLFGSPLGKDLLFKDSAFGLLRVPPRMDYRLYLGHSYVTAIRNQREGVCPEGSIDSAPVKWCALSHQERAKCDEWSVSSNGQIECESAESTEDCIDKIVNGEADAMSLDGGHAYIAGQCGLVPVMAENYDISSCTNPQSDVFPKGYYAVAVVKASDSSINWNNLKGKKSCHTGVDRTAGWNIPMGLLFSRINHCKFDEFFSQGCAPGYKKNSTLCDLCIGPAKCAPNNREGYNGYTGAFQCLVEKGDVAFVKHQTVLENTNGKNTAAWAKDLKQEDFQLLCPDGTKKPVTEFATCHLAQAPNHVVVSRKEKAARVSTVLTAQKDLFWKGDKDCTGNFCLFRSSTKDLLFRDDTKCLTKLPEGTTYEEYLGAEYLQAVGNIRKCSTSRLLEACTFHKS", p.getSequenceString());
-			
-		//	p = proteins.get("IPI00003881");
-		//    assertNotNull(p);
-		//	assertEquals("IPI00003881", p.getAccession());
-		//	assertEquals("Heterogeneous nuclear ribonucleoprotein F (hnRNP F) (Nucleolin-like protein mcs94-1) [Cleaved into: Heterogeneous nuclear ribonucleoprotein F, N-terminally processed]", p.getName());
-		//	assertEquals("MMLGPEGGEGFVVKLRGLPWSCSVEDVQNFLSDCTIHDGAAGVHFIYTREGRQSGEAFVELGSEDDVKMALKKDRESMGHRYIEVFKSHRTEMDWVLKHSGPNSADSANDGFVRLRGLPFGCTKEEIVQFFSGLEIVPNGITLPVDPEGKITGEAFVQFASQELAEKALGKHKERIGHRYIEVFKSSQEEVRSYSDPPLKFMSVQRPGPYDRPGTARRYIGIVKQAGLERMRPGAYSTGYGGYEEYSGLSDGYGFTTDLFGRDLSYCLSGMYDHRYGDSEFTVQSTTGHCVHMRGLPYKATENDIYNFFSPLNPVRVHIEIGPDGRVTGEADVEFATHEEAVAAMSKDRANMQHRYIELFLNSTTGASNGAYSSQVMQGMGVSAAQATYSGLESQSVSGCYGAGYSGQNSMGGYD", p.getSequenceString());
-		//assertEquals("", p.getProperty(PROPERTY.ACCESSION_VERSION));
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-	
-	public void testDemerged() {
-		ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
-		
-		ArrayList<String> accessions = new ArrayList<String>(3);
-		accessions.add("P02551");
-		accessions.add("P17073");
-		
-		try {
-			Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
-			
-			Protein p = proteins.get("P02551");
-			assertNotNull(p);
-			assertEquals("P02551", p.getAccession());
-			assertEquals(3, p.getReplacingProteins().size());
-			assertEquals(STATUS.DEMERGED, p.getStatus());
-			
-			p = proteins.get("P17073");
-			assertNotNull(p);
-			assertEquals("P17073", p.getAccession());
-			assertEquals(2, p.getReplacingProteins().size());
-			assertEquals(STATUS.DEMERGED, p.getStatus());
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-	
-	public void testMerged() {
-		ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
-		
-		ArrayList<String> accessions = new ArrayList<String>(3);
-		accessions.add("O88541");
-		accessions.add("Q63332");
-		
-		try {
-			Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
-			
-			Protein p = proteins.get("O88541");
-			assertNotNull(p);
-			assertEquals("O88541", p.getAccession());
-			assertEquals(1, p.getReplacingProteins().size());
-			assertEquals("P24368", p.getReplacingProteins().get(0).getAccession());
-			assertEquals(STATUS.MERGED, p.getStatus());
-			
-			p = proteins.get("Q63332");
-			assertNotNull(p);
-			assertEquals("Q63332", p.getAccession());
-			assertEquals(1, p.getReplacingProteins().size());
-			assertEquals("Q63041", p.getReplacingProteins().get(0).getAccession());
-			assertEquals(STATUS.MERGED, p.getStatus());
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-	
-	public void testIpi() {
-		ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
-		
-		ArrayList<String> accessions = new ArrayList<String>(3);
-		accessions.add("IPI00807607.1");
-		accessions.add("IPI00412408"); // multiple
-		accessions.add("IPI00359703.1"); // deleted
-		
-		try {
-			Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
-			
-			Protein p;
-			
-			p = proteins.get("IPI00807607");
-			assertNotNull(p);
-			assertEquals("IPI00807607", p.getAccession());
+  public void testGetProteinDetails() {
+    ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
+    ArrayList<String> accessions = new ArrayList<>(3);
+    accessions.add("P12345");
+    accessions.add("P12346");
+    accessions.add("P12347");
+    accessions.add("TRFE_RAT"); // id for P12346
+    accessions.add("IPI00003881");
+    accessions.add("ENSP00000263100");
+    accessions.add("NP_004788");
+    accessions.add("120666");
+    accessions.add("157327346");
+    try {
+      Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
+      assertEquals(9, proteins.size());
+      Protein p = proteins.get("P12345");
+      assertNotNull(p);
+      assertEquals("P12345", p.getAccession());
+      assertEquals("Aspartate aminotransferase, mitochondrial (mAspAT) (EC 2.6.1.1) (EC 2.6.1.7) (Fatty acid-binding protein) (FABP-1) (Glutamate oxaloacetate transaminase 2) (Kynurenine aminotransferase 4) (Kynurenine aminotransferase IV) (Kynurenine--oxoglutarate transaminase 4) (Kynurenine--oxoglutarate transaminase IV) (Plasma membrane-associated fatty acid-binding protein) (FABPpm) (Transaminase A)", p.getName());
+      assertEquals("MALLHSARVLSGVASAFHPGLAAAASARASSWWAHVEMGPPDPILGVTEAYKRDTNSKKMNLGVGAYRDDNGKPYVLPSVRKAEAQIAAKGLDKEYLPIGGLAEFCRASAELALGENSEVVKSGRFVTVQTISGTGALRIGASFLQRFFKFSRDVFLPKPSWGNHTPIFRDAGMQLQSYRYYDPKTCGFDFTGALEDISKIPEQSVLLLHACAHNPTGVDPRPEQWKEIATVVKKRNLFAFFDMAYQGFASGDGDKDAWAVRHFIEQGINVCLCQSYAKNMGLYGERVGAFTVICKDADEAKRVESQLKILIRPMYSNPPIHGARIASTILTSPDLRKQWLQEVKGMADRIIGMRTQLVSNLKKEGSTHSWQHITDQIGMFCFTGLKPEQVERLTKEFSIYMTKDGRISVAGVTSGNVGYLAHAIHQVTK", p.getSequenceString());
+      p = proteins.get("TRFE_RAT");
+      assertNotNull(p);
+      assertEquals("TRFE_RAT", p.getAccession());
+      assertEquals("Serotransferrin (Transferrin) (Beta-1 metal-binding globulin) (Liver regeneration-related protein LRRG03) (Siderophilin)", p.getName());
+      assertEquals("MRFAVGALLACAALGLCLAVPDKTVKWCAVSEHENTKCISFRDHMKTVLPADGPRLACVKKTSYQDCIKAISGGEADAITLDGGWVYDAGLTPNNLKPVAAEFYGSLEHPQTHYLAVAVVKKGTDFQLNQLQGKKSCHTGLGRSAGWIIPIGLLFCNLPEPRKPLEKAVASFFSGSCVPCADPVAFPQLCQLCPGCGCSPTQPFFGYVGAFKCLRDGGGDVAFVKHTTIFEVLPQKADRDQYELLCLDNTRKPVDQYEDCYLARIPSHAVVARNGDGKEDLIWEILKVAQEHFGKGKSKDFQLFGSPLGKDLLFKDSAFGLLRVPPRMDYRLYLGHSYVTAIRNQREGVCPEGSIDSAPVKWCALSHQERAKCDEWSVSSNGQIECESAESTEDCIDKIVNGEADAMSLDGGHAYIAGQCGLVPVMAENYDISSCTNPQSDVFPKGYYAVAVVKASDSSINWNNLKGKKSCHTGVDRTAGWNIPMGLLFSRINHCKFDEFFSQGCAPGYKKNSTLCDLCIGPAKCAPNNREGYNGYTGAFQCLVEKGDVAFVKHQTVLENTNGKNTAAWAKDLKQEDFQLLCPDGTKKPVTEFATCHLAQAPNHVVVSRKEKAARVSTVLTAQKDLFWKGDKDCTGNFCLFRSSTKDLLFRDDTKCLTKLPEGTTYEEYLGAEYLQAVGNIRKCSTSRLLEACTFHKS", p.getSequenceString());
+      p = proteins.get("P12346");
+      assertNotNull(p);
+      assertEquals("P12346", p.getAccession());
+      assertEquals("Serotransferrin (Transferrin) (Beta-1 metal-binding globulin) (Liver regeneration-related protein LRRG03) (Siderophilin)", p.getName());
+      assertEquals("MRFAVGALLACAALGLCLAVPDKTVKWCAVSEHENTKCISFRDHMKTVLPADGPRLACVKKTSYQDCIKAISGGEADAITLDGGWVYDAGLTPNNLKPVAAEFYGSLEHPQTHYLAVAVVKKGTDFQLNQLQGKKSCHTGLGRSAGWIIPIGLLFCNLPEPRKPLEKAVASFFSGSCVPCADPVAFPQLCQLCPGCGCSPTQPFFGYVGAFKCLRDGGGDVAFVKHTTIFEVLPQKADRDQYELLCLDNTRKPVDQYEDCYLARIPSHAVVARNGDGKEDLIWEILKVAQEHFGKGKSKDFQLFGSPLGKDLLFKDSAFGLLRVPPRMDYRLYLGHSYVTAIRNQREGVCPEGSIDSAPVKWCALSHQERAKCDEWSVSSNGQIECESAESTEDCIDKIVNGEADAMSLDGGHAYIAGQCGLVPVMAENYDISSCTNPQSDVFPKGYYAVAVVKASDSSINWNNLKGKKSCHTGVDRTAGWNIPMGLLFSRINHCKFDEFFSQGCAPGYKKNSTLCDLCIGPAKCAPNNREGYNGYTGAFQCLVEKGDVAFVKHQTVLENTNGKNTAAWAKDLKQEDFQLLCPDGTKKPVTEFATCHLAQAPNHVVVSRKEKAARVSTVLTAQKDLFWKGDKDCTGNFCLFRSSTKDLLFRDDTKCLTKLPEGTTYEEYLGAEYLQAVGNIRKCSTSRLLEACTFHKS", p.getSequenceString());
+    }
+    catch(Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 
-			p = proteins.get("IPI00412408");
-			assertNotNull(p);
+  public void testDemerged() {
+    ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
+    ArrayList<String> accessions = new ArrayList<>(3);
+    accessions.add("P02551");
+    accessions.add("P17073");
+    try {
+      Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
+      Protein p = proteins.get("P02551");
+      assertNotNull(p);
+      assertEquals("P02551", p.getAccession());
+      assertEquals(3, p.getReplacingProteins().size());
+      assertEquals(STATUS.DEMERGED, p.getStatus());
+      p = proteins.get("P17073");
+      assertNotNull(p);
+      assertEquals("P17073", p.getAccession());
+      assertEquals(2, p.getReplacingProteins().size());
+      assertEquals(STATUS.DEMERGED, p.getStatus());
+    }
+    catch(Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 
-            p =   proteins.get("IPI00359703");
-            assertNotNull(p);
-            assertNull(p.getName());
-			assertEquals(STATUS.UNKNOWN, p.getStatus());
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-	
-	public void testNcbi() {
-		ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
-		
-		ArrayList<String> accessions = new ArrayList<String>(3);
-		accessions.add("XP_216558");
-		accessions.add("XP_217055");
-		accessions.add("XP_224609");
-		accessions.add("XP_218966.2"); // deleted
-		
-		try {
-			Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
-			
-			Protein p;
-			
-			p = proteins.get("XP_216558");
-			assertNotNull(p);
-			assertEquals("XP_216558", p.getAccession());
-			
-			p = proteins.get("XP_217055");
-			assertNotNull(p);
-			assertEquals("XP_217055", p.getAccession());
-			assertEquals(STATUS.UNKNOWN, p.getStatus());
-			assertEquals(0, p.getReplacingProteins().size());
+  public void testMerged() {
+    ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
+    ArrayList<String> accessions = new ArrayList<>(3);
+    accessions.add("O88541");
+    accessions.add("Q63332");
+    try {
+      Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
+      Protein p = proteins.get("O88541");
+      assertNotNull(p);
+      assertEquals("O88541", p.getAccession());
+      assertEquals(1, p.getReplacingProteins().size());
+      assertEquals("P24368", p.getReplacingProteins().get(0).getAccession());
+      assertEquals(STATUS.MERGED, p.getStatus());
+      p = proteins.get("Q63332");
+      assertNotNull(p);
+      assertEquals("Q63332", p.getAccession());
+      assertEquals(1, p.getReplacingProteins().size());
+      assertEquals("Q63041", p.getReplacingProteins().get(0).getAccession());
+      assertEquals(STATUS.MERGED, p.getStatus());
+    }
+    catch(Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 
-			p = proteins.get("XP_218966");
-			assertNotNull(p);
-			assertEquals("XP_218966", p.getAccession());
-			assertEquals(STATUS.UNKNOWN, p.getStatus());
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-	
-	public void testUniprotIds() {
-		ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
-		
-		ArrayList<String> accessions = new ArrayList<String>(3);
-		accessions.add("CH601_ECOK1");
-		accessions.add("PYGB_BOVIN");
-		
-		try {
-			Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
-			
-			Protein p;
-			
-			p = proteins.get("CH601_ECOK1");
-			assertNotNull(p);
-			assertEquals("CH601_ECOK1", p.getAccession());
-			assertEquals(STATUS.ACTIVE, p.getStatus());
-			assertEquals("60 kDa chaperonin 1 (GroEL protein 1) (Protein Cpn60 1)", p.getName());
-			assertEquals("MAAKDVKFGNDARVKMLRGVNVLADAVKVTLGPKGRNVVLDKSFGAPTITKDGVSVAREIELEDKFENMGAQMVKEVASKANDAAGDGTTTATVLAQAIITEGLKAVAAGMNPMDLKRGIDKAVTAAVEELKALSVPCSDSKAIAQVGTISANSDETVGKLIAEAMDKVGKEGVITVEDGTGLQDELDVVEGMQFDRGYLSPYFINKPETGAVELESPFILLADKKISNIREMLPVLEAVAKAGKPLLIIAEDVEGEALATLVVNTMRGIVKVAAVKAPGFGDRRKAMLQDIATLTGGTVISEEIGMELEKATLEDLGQAKRVVINKDTTTIIDGVGEEAAIQGRVAQIRQQIEEATSDYDREKLQERVAKLAGGVAVIKVGAATEVEMKEKKARVEDALHATRAAVEEGVVAGGGVALIRVASKLADLRGQNEDQNVGIKVALRAMEAPLRQIVLNCGEEPSVVANTVKGGDGNYGYNAATEEYGNMIDMGILDPTKVTRSALQYAASVAGLMITTECMVTDLPKNDAADLGAAGGMGGMGGMGGMM", p.getSequenceString());
-			
-			p = proteins.get("PYGB_BOVIN");
-			assertNotNull(p);
-			assertEquals(STATUS.ACTIVE, p.getStatus());
-			assertEquals("Glycogen phosphorylase, brain form (EC 2.4.1.1)", p.getName());
-			assertEquals("MAKPLTDGERRKQISVRGLAGLGDVAEVRKSFNRHLHFTLVKDRNVATRRDYYLALAHTVRDHLVGRWIRTQQRYYERDPKRIYYLSLEFYMGRTLQNTMVNLGLQNACDEAIYQLGLDLEELEEIEEDAGLGNGGLGRLAACFLDSMATLGLAAYGYGIRYEFGIFNQKIVNGWQVEEADDWLRYGNPWEKARPEYMLPVHFYGRVEHSPEGVRWLDTQVVLAMPYDTPVPGYKNDTVNTMRLWSAKAPNDFKLHDFNVGGYIEAVLDRNLAENISRVLYPNDNFFEGKELRLKQEYFVVAATLQDIIRRFKSSKFGCRDPVRTSFETFPDKVAIQLNDTHPALAIPELMRILVDVEKVDWDKAWEITKKTCAYTNHTVLPEALERWPVSMFEKLLPRHLDIIYAINQRHLDHVAALFPGDVDRLRRMSVIEEGDCKRINMAHLCVIGSHAVNGVARIHSEIVRQSVFKDFYELEPEKFQNKTNGITPRRWLLLCNPGLAETIVERIGEGFLTDLSQLKKLLPLVGDEALIRDVAQVKQENKVKFSAFLEKQYGVKVNPSSMFDVHVKRIHEYKRQLLNCLHVVTLYNRIKKDPTQAFVPRTVMIGGKAAPGYHMAKKIIKLVTSIGNIVNHDPIVGDRLKVIFLENYRVSLAEKVIPAADLSQQISTAGTEASGTGNMKFMLNGALTIGTMDGANVEMAEEAGAENLFIFGLRVEDVEALDRKGYNAHEYYDRLPELRQAVDQINGGFFSPREPDCFKDVVNMLLNHDRFKVFADYEAYVACQARVDQLYRNPKEWTKKVIRNIACSGKFSSDRTITEYAHDIWGAEPPALQTPPPSLPRD", p.getSequenceString());
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
+  public void testNcbi() {
+    ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
+    ArrayList<String> accessions = new ArrayList<>(3);
+    accessions.add("XP_216558");
+    accessions.add("XP_217055");
+    accessions.add("XP_224609");
+    accessions.add("XP_218966.2"); // deleted
+    try {
+      Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
+      Protein p;
+      p = proteins.get("XP_216558");
+      assertNotNull(p);
+      assertEquals("XP_216558", p.getAccession());
+      p = proteins.get("XP_217055");
+      assertNotNull(p);
+      assertEquals("XP_217055", p.getAccession());
+      assertEquals(STATUS.UNKNOWN, p.getStatus());
+      assertEquals(0, p.getReplacingProteins().size());
+      p = proteins.get("XP_218966");
+      assertNotNull(p);
+      assertEquals("XP_218966", p.getAccession());
+      assertEquals(STATUS.UNKNOWN, p.getStatus());
+    }
+    catch(Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 
-	public void testDeletedUniprot() {
-		ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
-		
-		ArrayList<String> accessions = new ArrayList<String>(3);
-		accessions.add("Q91WS9");
-		
-		try {
-			Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
-			
-			Protein p;
-			
-			p = proteins.get("Q91WS9");
-			assertNotNull(p);
-			assertEquals("Q91WS9", p.getAccession());
-			assertEquals(STATUS.DELETED, p.getStatus());
-		}
-		catch(Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
+  public void testUniprotIds() {
+    ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
+    ArrayList<String> accessions = new ArrayList<>(3);
+    accessions.add("CH601_ECOK1");
+    accessions.add("PYGB_BOVIN");
+    try {
+      Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
+      Protein p;
+      p = proteins.get("CH601_ECOK1");
+      assertNotNull(p);
+      assertEquals("CH601_ECOK1", p.getAccession());
+      assertEquals(STATUS.ACTIVE, p.getStatus());
+      assertEquals("60 kDa chaperonin 1 (GroEL protein 1) (Protein Cpn60 1)", p.getName());
+      assertEquals("MAAKDVKFGNDARVKMLRGVNVLADAVKVTLGPKGRNVVLDKSFGAPTITKDGVSVAREIELEDKFENMGAQMVKEVASKANDAAGDGTTTATVLAQAIITEGLKAVAAGMNPMDLKRGIDKAVTAAVEELKALSVPCSDSKAIAQVGTISANSDETVGKLIAEAMDKVGKEGVITVEDGTGLQDELDVVEGMQFDRGYLSPYFINKPETGAVELESPFILLADKKISNIREMLPVLEAVAKAGKPLLIIAEDVEGEALATLVVNTMRGIVKVAAVKAPGFGDRRKAMLQDIATLTGGTVISEEIGMELEKATLEDLGQAKRVVINKDTTTIIDGVGEEAAIQGRVAQIRQQIEEATSDYDREKLQERVAKLAGGVAVIKVGAATEVEMKEKKARVEDALHATRAAVEEGVVAGGGVALIRVASKLADLRGQNEDQNVGIKVALRAMEAPLRQIVLNCGEEPSVVANTVKGGDGNYGYNAATEEYGNMIDMGILDPTKVTRSALQYAASVAGLMITTECMVTDLPKNDAADLGAAGGMGGMGGMGGMM", p.getSequenceString());
+      p = proteins.get("PYGB_BOVIN");
+      assertNotNull(p);
+      assertEquals(STATUS.ACTIVE, p.getStatus());
+      assertEquals("Glycogen phosphorylase, brain form (EC 2.4.1.1)", p.getName());
+      assertEquals("MAKPLTDGERRKQISVRGLAGLGDVAEVRKSFNRHLHFTLVKDRNVATRRDYYLALAHTVRDHLVGRWIRTQQRYYERDPKRIYYLSLEFYMGRTLQNTMVNLGLQNACDEAIYQLGLDLEELEEIEEDAGLGNGGLGRLAACFLDSMATLGLAAYGYGIRYEFGIFNQKIVNGWQVEEADDWLRYGNPWEKARPEYMLPVHFYGRVEHSPEGVRWLDTQVVLAMPYDTPVPGYKNDTVNTMRLWSAKAPNDFKLHDFNVGGYIEAVLDRNLAENISRVLYPNDNFFEGKELRLKQEYFVVAATLQDIIRRFKSSKFGCRDPVRTSFETFPDKVAIQLNDTHPALAIPELMRILVDVEKVDWDKAWEITKKTCAYTNHTVLPEALERWPVSMFEKLLPRHLDIIYAINQRHLDHVAALFPGDVDRLRRMSVIEEGDCKRINMAHLCVIGSHAVNGVARIHSEIVRQSVFKDFYELEPEKFQNKTNGITPRRWLLLCNPGLAETIVERIGEGFLTDLSQLKKLLPLVGDEALIRDVAQVKQENKVKFSAFLEKQYGVKVNPSSMFDVHVKRIHEYKRQLLNCLHVVTLYNRIKKDPTQAFVPRTVMIGGKAAPGYHMAKKIIKLVTSIGNIVNHDPIVGDRLKVIFLENYRVSLAEKVIPAADLSQQISTAGTEASGTGNMKFMLNGALTIGTMDGANVEMAEEAGAENLFIFGLRVEDVEALDRKGYNAHEYYDRLPELRQAVDQINGGFFSPREPDCFKDVVNMLLNHDRFKVFADYEAYVACQARVDQLYRNPKEWTKKVIRNIACSGKFSSDRTITEYAHDIWGAEPPALQTPPPSLPRD", p.getSequenceString());
+    }
+    catch(Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  public void testDeletedUniprot() {
+    ProteinDetailFetcher fetcher = new ProteinDetailFetcher();
+    ArrayList<String> accessions = new ArrayList<>(3);
+    accessions.add("Q91WS9");
+    try {
+      Map<String, Protein> proteins = fetcher.getProteinDetails(accessions);
+      Protein p;
+      p = proteins.get("Q91WS9");
+      assertNotNull(p);
+      assertEquals("Q91WS9", p.getAccession());
+      assertEquals(STATUS.DELETED, p.getStatus());
+    }
+    catch(Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
I have removed support for IPI and GI accessions now because they have been deprecated with Uniprot and no longer supported. As such quite a few methods are now thrown away. I have cleaned up the code in general so it's easier to read, removed superfluous comments, added some Javadoc (most of it is lacking still), some variable names, removed unused variables, imports, etc. A lot of general housekeeping, plus updated the POM to use the new 'pride-core' parent for use with our Bamboo.

The unit tests have been tidied up as well and work OK.

There is currently 1 bug with Uniprot about the header line in tabbed results [help #132525] which may be fixed by their next release on 12th May, see the getUniProtDetails() method. This will be need to be slightly updated again in the future when it's back to normal.